### PR TITLE
feat: Optimize for privacy and LCP

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,12 +47,7 @@
       "priceRange": "Зависит от сложности дела"
     }
     </script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
-    <noscript><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet"></noscript>
     <meta name="color-scheme" content="light dark">
-    <link rel="preload" href="/src/assets/photo.jpg" as="image">
 
   </head>
   <body>

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -51,7 +51,7 @@
     0 5px 10px rgba(0, 0, 0, 0.35), 0 2px 3px rgba(0, 0, 0, 0.2);
 
   --font-family-base:
-    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
     Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   --font-size-base: 1rem;
   --font-size-sm: 0.875rem;

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -29,7 +29,7 @@
               src="@/assets/photo.jpg"
               alt="Фотография Шкоды Алексея Игоревича"
               class="lawyer-photo"
-              loading="lazy"
+              fetchpriority="high"
               width="256"
               height="256"
             />


### PR DESCRIPTION
This commit introduces several optimizations based on user feedback and a PageSpeed report.

- Replaces Google Fonts with a system font stack to improve privacy and performance.
- Removes all links and preconnects to Google Fonts services from `index.html`.
- Updates the base CSS to remove the "Inter" font family.

- Optimizes the Largest Contentful Paint (LCP) image by replacing `loading="lazy"` with `fetchpriority="high"`. This signals to the browser to prioritize loading this critical image.
- Removes an ineffective image preload link from `index.html`.